### PR TITLE
Updated deprecated `Cucumber::Ast::Table` to `Cucumber::MultilineArgument::DataTable`

### DIFF
--- a/lib/cucumber/rest_api.rb
+++ b/lib/cucumber/rest_api.rb
@@ -44,7 +44,7 @@ When /^I send a (GET|POST|PUT|DELETE) request (?:for|to) "([^"]*)"(?: with the f
   request_opts = {method: request_type.downcase.to_sym}
 
   unless input.nil?
-    if input.class == Cucumber::Ast::Table
+    if input.class == Cucumber::MultilineArgument::DataTable
       request_opts[:params] = input.rows_hash
     else
       request_opts[:input] = input


### PR DESCRIPTION
`Cucumber::Ast::Table` has been deprecated. I updated it to use `Cucumber::MultilineArgument::DataTable` instead to clear the warning message from console.